### PR TITLE
[license] Unify license headers

### DIFF
--- a/examples/monitor/client.cpp
+++ b/examples/monitor/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/context.h>
 #include <airmap/monitor/client.h>
 #include <airmap/util/formatting_logger.h>

--- a/examples/qt/client.cpp
+++ b/examples/qt/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "client.h"
 
 #include <airmap/qt/client.h>

--- a/examples/qt/client.h
+++ b/examples/qt/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_EXAMPLES_QT_CLIENT_H_
 #define AIRMAP_EXAMPLES_QT_CLIENT_H_
 

--- a/include/airmap/advisory.h
+++ b/include/airmap/advisory.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_ADVISORY_H_
 #define AIRMAP_ADVISORY_H_
 

--- a/include/airmap/aircraft.h
+++ b/include/airmap/aircraft.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircraft.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRCRAFT_H_
 #define AIRMAP_AIRCRAFT_H_
 

--- a/include/airmap/aircrafts.h
+++ b/include/airmap/aircrafts.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRCRAFTS_H_
 #define AIRMAP_AIRCRAFTS_H_
 

--- a/include/airmap/airspace.h
+++ b/include/airmap/airspace.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspace.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRSPACE_H_
 #define AIRMAP_AIRSPACE_H_
 

--- a/include/airmap/airspaces.h
+++ b/include/airmap/airspaces.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRSPACES_H_
 #define AIRMAP_AIRSPACES_H_
 

--- a/include/airmap/authenticator.h
+++ b/include/airmap/authenticator.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AUTHENTICATOR_H_
 #define AIRMAP_AUTHENTICATOR_H_
 

--- a/include/airmap/client.h
+++ b/include/airmap/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CLIENT_H_
 #define AIRMAP_CLIENT_H_
 

--- a/include/airmap/context.h
+++ b/include/airmap/context.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  context.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CONTEXT_H_
 #define AIRMAP_CONTEXT_H_
 

--- a/include/airmap/credentials.h
+++ b/include/airmap/credentials.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  credentials.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CREDENTIALS_H_
 #define AIRMAP_CREDENTIALS_H_
 

--- a/include/airmap/date_time.h
+++ b/include/airmap/date_time.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  date_time.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_DATE_TIME_H_
 #define AIRMAP_DATE_TIME_H_
 

--- a/include/airmap/do_not_copy_or_move.h
+++ b/include/airmap/do_not_copy_or_move.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  do_not_copy_or_move.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_DO_NOT_COPY_OR_MOVE_H_
 #define AIRMAP_DO_NOT_COPY_OR_MOVE_H_
 

--- a/include/airmap/error.h
+++ b/include/airmap/error.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  error.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_ERROR_H_
 #define AIRMAP_ERROR_H_
 

--- a/include/airmap/evaluation.h
+++ b/include/airmap/evaluation.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  evaluation.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_EVALUATION_H_
 #define AIRMAP_EVALUATION_H_
 

--- a/include/airmap/flight.h
+++ b/include/airmap/flight.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHT_H_
 #define AIRMAP_FLIGHT_H_
 

--- a/include/airmap/flight_plan.h
+++ b/include/airmap/flight_plan.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plan.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHT_PLAN_H_
 #define AIRMAP_FLIGHT_PLAN_H_
 

--- a/include/airmap/flight_plans.h
+++ b/include/airmap/flight_plans.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHT_PLANS_H_
 #define AIRMAP_FLIGHT_PLANS_H_
 

--- a/include/airmap/flights.h
+++ b/include/airmap/flights.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHTS_H_
 #define AIRMAP_FLIGHTS_H_
 

--- a/include/airmap/geometry.h
+++ b/include/airmap/geometry.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  geometry.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GEOMETRY_H_
 #define AIRMAP_GEOMETRY_H_
 

--- a/include/airmap/logger.h
+++ b/include/airmap/logger.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  logger.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_LOGGER_H_
 #define AIRMAP_LOGGER_H_
 

--- a/include/airmap/monitor/client.h
+++ b/include/airmap/monitor/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_CLIENT_H_
 #define AIRMAP_MONITOR_CLIENT_H_
 

--- a/include/airmap/optional.h
+++ b/include/airmap/optional.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  optional.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_OPTIONAL_H_
 #define AIRMAP_OPTIONAL_H_
 

--- a/include/airmap/outcome.h
+++ b/include/airmap/outcome.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  outcome.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_OUTCOME_H_
 #define AIRMAP_OUTCOME_H_
 

--- a/include/airmap/pilot.h
+++ b/include/airmap/pilot.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilot.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PILOT_H_
 #define AIRMAP_PILOT_H_
 

--- a/include/airmap/pilots.h
+++ b/include/airmap/pilots.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PILOTS_H_
 #define AIRMAP_PILOTS_H_
 

--- a/include/airmap/qt/client.h
+++ b/include/airmap/qt/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_CLIENT_H_
 #define AIRMAP_QT_CLIENT_H_
 

--- a/include/airmap/qt/logger.h
+++ b/include/airmap/qt/logger.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  logger.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_LOGGER_H_
 #define AIRMAP_QT_LOGGER_H_
 

--- a/include/airmap/qt/types.h
+++ b/include/airmap/qt/types.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  types.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_TYPES_H_
 #define AIRMAP_QT_TYPES_H_
 

--- a/include/airmap/rule.h
+++ b/include/airmap/rule.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rule.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_RULE_H_
 #define AIRMAP_RULE_H_
 

--- a/include/airmap/ruleset.h
+++ b/include/airmap/ruleset.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  ruleset.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_RULESET_H_
 #define AIRMAP_RULESET_H_
 

--- a/include/airmap/rulesets.h
+++ b/include/airmap/rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_RULESETS_H_
 #define AIRMAP_RULESETS_H_
 

--- a/include/airmap/status.h
+++ b/include/airmap/status.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_STATUS_H_
 #define AIRMAP_STATUS_H_
 

--- a/include/airmap/telemetry.h
+++ b/include/airmap/telemetry.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TELEMETRY_H_
 #define AIRMAP_TELEMETRY_H_
 

--- a/include/airmap/timestamp.h
+++ b/include/airmap/timestamp.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  timestamp.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TIMESTAMP_H_
 #define AIRMAP_TIMESTAMP_H_
 

--- a/include/airmap/token.h
+++ b/include/airmap/token.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  token.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TOKEN_H_
 #define AIRMAP_TOKEN_H_
 

--- a/include/airmap/traffic.h
+++ b/include/airmap/traffic.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TRAFFIC_H_
 #define AIRMAP_TRAFFIC_H_
 

--- a/include/airmap/version.h
+++ b/include/airmap/version.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  version.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_VERSION_H_
 #define AIRMAP_VERSION_H_
 

--- a/include/airmap/visibility.h
+++ b/include/airmap/visibility.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  visibility.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_VISIBILITY_H_
 #define AIRMAP_VISIBILITY_H_
 

--- a/src/airmap/airspace.cpp
+++ b/src/airmap/airspace.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspace.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/airspace.h>
 
 #include <iostream>

--- a/src/airmap/boost/context.cpp
+++ b/src/airmap/boost/context.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  context.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/boost/context.h>
 
 #include <airmap/net/http/boost/requester.h>

--- a/src/airmap/boost/context.h
+++ b/src/airmap/boost/context.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  context.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_BOOST_CONTEXT_H_
 #define AIRMAP_BOOST_CONTEXT_H_
 

--- a/src/airmap/client.cpp
+++ b/src/airmap/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/client.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/cmds/airmap/airmap.cpp
+++ b/src/airmap/cmds/airmap/airmap.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airmap.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/add_aircraft.h>
 #include <airmap/cmds/airmap/cmd/aircraft_models.h>
 #include <airmap/cmds/airmap/cmd/create_flight.h>

--- a/src/airmap/cmds/airmap/cmd/add_aircraft.cpp
+++ b/src/airmap/cmds/airmap/cmd/add_aircraft.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  add_aircraft.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/add_aircraft.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/add_aircraft.h
+++ b/src/airmap/cmds/airmap/cmd/add_aircraft.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  add_aircraft.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_ADD_AIRCRAFT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_ADD_AIRCRAFT_H_
 

--- a/src/airmap/cmds/airmap/cmd/aircraft_models.cpp
+++ b/src/airmap/cmds/airmap/cmd/aircraft_models.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircraft_models.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/aircraft_models.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/aircraft_models.h
+++ b/src/airmap/cmds/airmap/cmd/aircraft_models.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircraft_models.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_AIRCRAFT_MODELS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_AIRCRAFT_MODELS_H_
 

--- a/src/airmap/cmds/airmap/cmd/create_flight.cpp
+++ b/src/airmap/cmds/airmap/cmd/create_flight.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  create_flight.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/create_flight.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/create_flight.h
+++ b/src/airmap/cmds/airmap/cmd/create_flight.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  create_flight.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_CREATE_FLIGHT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_CREATE_FLIGHT_H_
 

--- a/src/airmap/cmds/airmap/cmd/daemon.cpp
+++ b/src/airmap/cmds/airmap/cmd/daemon.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  daemon.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/daemon.h>
 
 #include <airmap/boost/context.h>

--- a/src/airmap/cmds/airmap/cmd/daemon.h
+++ b/src/airmap/cmds/airmap/cmd/daemon.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  daemon.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_DAEMON_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_DAEMON_H_
 

--- a/src/airmap/cmds/airmap/cmd/end_flight.cpp
+++ b/src/airmap/cmds/airmap/cmd/end_flight.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  end_flight.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/end_flight.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/end_flight.h
+++ b/src/airmap/cmds/airmap/cmd/end_flight.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  end_flight.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_END_FLIGHT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_END_FLIGHT_H_
 

--- a/src/airmap/cmds/airmap/cmd/end_flight_comms.cpp
+++ b/src/airmap/cmds/airmap/cmd/end_flight_comms.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  end_flight_comms.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/end_flight_comms.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/end_flight_comms.h
+++ b/src/airmap/cmds/airmap/cmd/end_flight_comms.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  end_flight_comms.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_END_FLIGHT_COMMS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_END_FLIGHT_COMMS_H_
 

--- a/src/airmap/cmds/airmap/cmd/evaluate_rulesets.cpp
+++ b/src/airmap/cmds/airmap/cmd/evaluate_rulesets.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  evaluate_rulesets.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/evaluate_rulesets.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/evaluate_rulesets.h
+++ b/src/airmap/cmds/airmap/cmd/evaluate_rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  evaluate_rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_EVALUATE_RULESETS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_EVALUATE_RULESETS_H_
 

--- a/src/airmap/cmds/airmap/cmd/fetch_rules.cpp
+++ b/src/airmap/cmds/airmap/cmd/fetch_rules.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  fetch_rules.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/fetch_rules.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/fetch_rules.h
+++ b/src/airmap/cmds/airmap/cmd/fetch_rules.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  fetch_rules.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_FETCH_RULES_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_FETCH_RULES_H_
 

--- a/src/airmap/cmds/airmap/cmd/flags.cpp
+++ b/src/airmap/cmds/airmap/cmd/flags.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flags.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/flags.h>
 
 namespace cli   = airmap::util::cli;

--- a/src/airmap/cmds/airmap/cmd/flags.h
+++ b/src/airmap/cmds/airmap/cmd/flags.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flags.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_FLAGS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_FLAGS_H_
 

--- a/src/airmap/cmds/airmap/cmd/get_advisories.cpp
+++ b/src/airmap/cmds/airmap/cmd/get_advisories.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  get_advisories.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/get_advisories.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/get_advisories.h
+++ b/src/airmap/cmds/airmap/cmd/get_advisories.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  get_advisories.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_GET_ADVISORIES_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_GET_ADVISORIES_H_
 

--- a/src/airmap/cmds/airmap/cmd/get_status.cpp
+++ b/src/airmap/cmds/airmap/cmd/get_status.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  get_status.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/get_status.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/get_status.h
+++ b/src/airmap/cmds/airmap/cmd/get_status.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  get_status.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_GET_STATUS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_GET_STATUS_H_
 

--- a/src/airmap/cmds/airmap/cmd/init.cpp
+++ b/src/airmap/cmds/airmap/cmd/init.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  init.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/init.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/cmds/airmap/cmd/init.h
+++ b/src/airmap/cmds/airmap/cmd/init.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  init.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_INIT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_INIT_H_
 

--- a/src/airmap/cmds/airmap/cmd/login.cpp
+++ b/src/airmap/cmds/airmap/cmd/login.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  login.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/login.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/login.h
+++ b/src/airmap/cmds/airmap/cmd/login.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  login.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_LOGIN_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_LOGIN_H_
 

--- a/src/airmap/cmds/airmap/cmd/monitor_mids.cpp
+++ b/src/airmap/cmds/airmap/cmd/monitor_mids.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  monitor_mids.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/monitor_mids.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/monitor_mids.h
+++ b/src/airmap/cmds/airmap/cmd/monitor_mids.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  monitor_mids.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_MONITOR_MIDS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_MONITOR_MIDS_H_
 

--- a/src/airmap/cmds/airmap/cmd/monitor_traffic.cpp
+++ b/src/airmap/cmds/airmap/cmd/monitor_traffic.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  monitor_traffic.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/monitor_traffic.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/monitor_traffic.h
+++ b/src/airmap/cmds/airmap/cmd/monitor_traffic.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  monitor_traffic.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_MONITOR_TRAFFIC_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_MONITOR_TRAFFIC_H_
 

--- a/src/airmap/cmds/airmap/cmd/pilot.cpp
+++ b/src/airmap/cmds/airmap/cmd/pilot.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilot.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/pilot.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/pilot.h
+++ b/src/airmap/cmds/airmap/cmd/pilot.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilot.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_PILOT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_PILOT_H_
 

--- a/src/airmap/cmds/airmap/cmd/plan_flight.cpp
+++ b/src/airmap/cmds/airmap/cmd/plan_flight.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  plan_flight.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/plan_flight.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/plan_flight.h
+++ b/src/airmap/cmds/airmap/cmd/plan_flight.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  plan_flight.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_PLAN_FLIGHT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_PLAN_FLIGHT_H_
 

--- a/src/airmap/cmds/airmap/cmd/query_rulesets.cpp
+++ b/src/airmap/cmds/airmap/cmd/query_rulesets.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  query_rulesets.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/query_rulesets.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/query_rulesets.h
+++ b/src/airmap/cmds/airmap/cmd/query_rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  query_rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_QUERY_RULESETS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_QUERY_RULESETS_H_
 

--- a/src/airmap/cmds/airmap/cmd/render_briefing.cpp
+++ b/src/airmap/cmds/airmap/cmd/render_briefing.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  render_briefing.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/render_briefing.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/render_briefing.h
+++ b/src/airmap/cmds/airmap/cmd/render_briefing.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  render_briefing.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_RENDER_BRIEFING_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_RENDER_BRIEFING_H_
 

--- a/src/airmap/cmds/airmap/cmd/report_weather.cpp
+++ b/src/airmap/cmds/airmap/cmd/report_weather.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  report_weather.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/report_weather.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/report_weather.h
+++ b/src/airmap/cmds/airmap/cmd/report_weather.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  report_weather.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_REPORT_WEATHER_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_REPORT_WEATHER_H_
 

--- a/src/airmap/cmds/airmap/cmd/search_airspace.cpp
+++ b/src/airmap/cmds/airmap/cmd/search_airspace.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  search_airspace.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/search_airspace.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/search_airspace.h
+++ b/src/airmap/cmds/airmap/cmd/search_airspace.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  search_airspace.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_SEARCH_AIRSPACE_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_SEARCH_AIRSPACE_H_
 

--- a/src/airmap/cmds/airmap/cmd/simulate_scenario.cpp
+++ b/src/airmap/cmds/airmap/cmd/simulate_scenario.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  simulate_scenario.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/simulate_scenario.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/simulate_scenario.h
+++ b/src/airmap/cmds/airmap/cmd/simulate_scenario.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  simulate_scenario.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_SIMULATE_SCENARIO_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_SIMULATE_SCENARIO_H_
 

--- a/src/airmap/cmds/airmap/cmd/simulate_telemetry.cpp
+++ b/src/airmap/cmds/airmap/cmd/simulate_telemetry.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  simulate_telemetry.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/simulate_telemetry.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/simulate_telemetry.h
+++ b/src/airmap/cmds/airmap/cmd/simulate_telemetry.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  simulate_telemetry.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_SIMULATE_TELEMETRY_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_SIMULATE_TELEMETRY_H_
 

--- a/src/airmap/cmds/airmap/cmd/start_flight_comms.cpp
+++ b/src/airmap/cmds/airmap/cmd/start_flight_comms.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  start_flight_comms.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/start_flight_comms.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/start_flight_comms.h
+++ b/src/airmap/cmds/airmap/cmd/start_flight_comms.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  start_flight_comms.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_START_FLIGHT_COMMS_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_START_FLIGHT_COMMS_H_
 

--- a/src/airmap/cmds/airmap/cmd/submit_flight.cpp
+++ b/src/airmap/cmds/airmap/cmd/submit_flight.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  submit_flight.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/submit_flight.h>
 
 #include <airmap/client.h>

--- a/src/airmap/cmds/airmap/cmd/submit_flight.h
+++ b/src/airmap/cmds/airmap/cmd/submit_flight.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  submit_flight.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_SUBMIT_FLIGHT_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_SUBMIT_FLIGHT_H_
 

--- a/src/airmap/cmds/airmap/cmd/test.cpp
+++ b/src/airmap/cmds/airmap/cmd/test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/test.h>
 
 #include <airmap/paths.h>

--- a/src/airmap/cmds/airmap/cmd/test.h
+++ b/src/airmap/cmds/airmap/cmd/test.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  test.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_TEST_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_TEST_H_
 

--- a/src/airmap/cmds/airmap/cmd/test/laanc.phoenix.cpp
+++ b/src/airmap/cmds/airmap/cmd/test/laanc.phoenix.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  laanc.phoenix.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/test/laanc.phoenix.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/cmds/airmap/cmd/test/laanc.phoenix.h
+++ b/src/airmap/cmds/airmap/cmd/test/laanc.phoenix.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  laanc.phoenix.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_TEST_LAANC_PHOENIX_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_TEST_LAANC_PHOENIX_H_
 

--- a/src/airmap/cmds/airmap/cmd/version.cpp
+++ b/src/airmap/cmds/airmap/cmd/version.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  version.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/cmds/airmap/cmd/version.h>
 
 namespace cli = airmap::util::cli;

--- a/src/airmap/cmds/airmap/cmd/version.h
+++ b/src/airmap/cmds/airmap/cmd/version.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  version.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CMDS_AIRMAP_CMD_VERSION_H_
 #define AIRMAP_CMDS_AIRMAP_CMD_VERSION_H_
 

--- a/src/airmap/codec.h
+++ b/src/airmap/codec.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  codec.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_H_
 #define AIRMAP_CODEC_H_
 

--- a/src/airmap/codec/grpc/date_time.cpp
+++ b/src/airmap/codec/grpc/date_time.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  date_time.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/grpc/date_time.h>
 
 void airmap::codec::grpc::decode(const ::google::protobuf::Timestamp& from, DateTime& to) {

--- a/src/airmap/codec/grpc/date_time.h
+++ b/src/airmap/codec/grpc/date_time.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  date_time.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_GRPC_DATE_TIME_H_
 #define AIRMAP_CODEC_GRPC_DATE_TIME_H_
 

--- a/src/airmap/codec/grpc/traffic.cpp
+++ b/src/airmap/codec/grpc/traffic.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/grpc/traffic.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/grpc/traffic.h
+++ b/src/airmap/codec/grpc/traffic.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_GRPC_TRAFFIC_H_
 #define AIRMAP_CODEC_GRPC_TRAFFIC_H_
 

--- a/src/airmap/codec/http/query/advisories.cpp
+++ b/src/airmap/codec/http/query/advisories.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisories.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/advisories.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/http/query/advisories.h
+++ b/src/airmap/codec/http/query/advisories.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisories.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_ADVISORY_H_
 #define AIRMAP_CODEC_HTTP_QUERY_ADVISORY_H_
 

--- a/src/airmap/codec/http/query/aircrafts.cpp
+++ b/src/airmap/codec/http/query/aircrafts.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/aircrafts.h>
 
 void airmap::codec::http::query::encode(std::unordered_map<std::string, std::string>& query,

--- a/src/airmap/codec/http/query/aircrafts.h
+++ b/src/airmap/codec/http/query/aircrafts.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_AIRCRAFTS_H_
 #define AIRMAP_CODEC_HTTP_QUERY_AIRCRAFTS_H_
 

--- a/src/airmap/codec/http/query/airspaces.cpp
+++ b/src/airmap/codec/http/query/airspaces.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/airspaces.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/http/query/airspaces.h
+++ b/src/airmap/codec/http/query/airspaces.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_AIRSPACES_H_
 #define AIRMAP_CODEC_HTTP_QUERY_AIRSPACES_H_
 

--- a/src/airmap/codec/http/query/flights.cpp
+++ b/src/airmap/codec/http/query/flights.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/flights.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/http/query/flights.h
+++ b/src/airmap/codec/http/query/flights.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_FLIGHTS_H_
 #define AIRMAP_CODEC_HTTP_QUERY_FLIGHTS_H_
 

--- a/src/airmap/codec/http/query/pilots.cpp
+++ b/src/airmap/codec/http/query/pilots.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/pilots.h>
 
 #include <airmap/date_time.h>

--- a/src/airmap/codec/http/query/pilots.h
+++ b/src/airmap/codec/http/query/pilots.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_PILOTS_H_
 #define AIRMAP_CODEC_HTTP_QUERY_PILOTS_H_
 

--- a/src/airmap/codec/http/query/rulesets.cpp
+++ b/src/airmap/codec/http/query/rulesets.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/rulesets.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/http/query/rulesets.h
+++ b/src/airmap/codec/http/query/rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_RULESETS_H_
 #define AIRMAP_CODEC_HTTP_QUERY_RULESETS_H_
 

--- a/src/airmap/codec/http/query/status.cpp
+++ b/src/airmap/codec/http/query/status.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/http/query/status.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/http/query/status.h
+++ b/src/airmap/codec/http/query/status.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_HTTP_QUERY_STATUS_H_
 #define AIRMAP_CODEC_HTTP_QUERY_STATUS_H_
 

--- a/src/airmap/codec/json/advisories.cpp
+++ b/src/airmap/codec/json/advisories.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisories.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/advisories.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/advisories.h
+++ b/src/airmap/codec/json/advisories.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisories.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_ADVISORIES_H_
 #define AIRMAP_CODEC_JSON_ADVISORIES_H_
 

--- a/src/airmap/codec/json/advisory.cpp
+++ b/src/airmap/codec/json/advisory.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/advisory.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/advisory.h
+++ b/src/airmap/codec/json/advisory.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_ADVISORY_H_
 #define AIRMAP_CODEC_JSON_ADVISORY_H_
 

--- a/src/airmap/codec/json/aircraft.cpp
+++ b/src/airmap/codec/json/aircraft.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircraft.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/aircraft.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/aircraft.h
+++ b/src/airmap/codec/json/aircraft.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircraft.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_AIRCRAFT_H_
 #define AIRMAP_CODEC_JSON_AIRCRAFT_H_
 

--- a/src/airmap/codec/json/airspace.cpp
+++ b/src/airmap/codec/json/airspace.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspace.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/airspace.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/airspace.h
+++ b/src/airmap/codec/json/airspace.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspace.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_AIRSPACE_H_
 #define AIRMAP_CODEC_JSON_AIRSPACE_H_
 

--- a/src/airmap/codec/json/authenticator.cpp
+++ b/src/airmap/codec/json/authenticator.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/authenticator.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/authenticator.h
+++ b/src/airmap/codec/json/authenticator.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_AUTHENTICATOR_H_
 #define AIRMAP_CODEC_JSON_AUTHENTICATOR_H_
 

--- a/src/airmap/codec/json/chrono.cpp
+++ b/src/airmap/codec/json/chrono.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  chrono.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/chrono.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/chrono.h
+++ b/src/airmap/codec/json/chrono.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  chrono.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_CHRONO_H_
 #define AIRMAP_CODEC_JSON_CHRONO_H_
 

--- a/src/airmap/codec/json/client.cpp
+++ b/src/airmap/codec/json/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/client.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/client.h
+++ b/src/airmap/codec/json/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_CLIENT_H_
 #define AIRMAP_CODEC_JSON_CLIENT_H_
 

--- a/src/airmap/codec/json/credentials.cpp
+++ b/src/airmap/codec/json/credentials.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  credentials.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/credentials.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/credentials.h
+++ b/src/airmap/codec/json/credentials.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  credentials.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_CREDENTIALS_H_
 #define AIRMAP_CODEC_JSON_CREDENTIALS_H_
 

--- a/src/airmap/codec/json/date_time.cpp
+++ b/src/airmap/codec/json/date_time.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  date_time.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/date_time.h>
 
 airmap::Seconds nlohmann::adl_serializer<airmap::Seconds>::from_json(const nlohmann::json& j) {

--- a/src/airmap/codec/json/date_time.h
+++ b/src/airmap/codec/json/date_time.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  date_time.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_DATE_TIME_H_
 #define AIRMAP_CODEC_JSON_DATE_TIME_H_
 

--- a/src/airmap/codec/json/evaluation.cpp
+++ b/src/airmap/codec/json/evaluation.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  evaluation.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/flight_plan.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/evaluation.h
+++ b/src/airmap/codec/json/evaluation.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  evaluation.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_EVALUATION_H_
 #define AIRMAP_CODEC_JSON_EVALUATION_H_
 

--- a/src/airmap/codec/json/flight.cpp
+++ b/src/airmap/codec/json/flight.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/flight.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/flight.h
+++ b/src/airmap/codec/json/flight.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_FLIGHT_H_
 #define AIRMAP_CODEC_JSON_FLIGHT_H_
 

--- a/src/airmap/codec/json/flight_plan.cpp
+++ b/src/airmap/codec/json/flight_plan.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plan.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/flight_plan.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/flight_plan.h
+++ b/src/airmap/codec/json/flight_plan.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plan.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_FLIGHT_PLAN_H_
 #define AIRMAP_CODEC_JSON_FLIGHT_PLAN_H_
 

--- a/src/airmap/codec/json/flight_plans.cpp
+++ b/src/airmap/codec/json/flight_plans.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/flight_plan.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/flight_plans.h
+++ b/src/airmap/codec/json/flight_plans.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_FLIGHT_PLANS_H_
 #define AIRMAP_CODEC_JSON_FLIGHT_PLANS_H_
 

--- a/src/airmap/codec/json/flights.cpp
+++ b/src/airmap/codec/json/flights.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/flights.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/flights.h
+++ b/src/airmap/codec/json/flights.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_FLIGHTS_H_
 #define AIRMAP_CODEC_JSON_FLIGHTS_H_
 

--- a/src/airmap/codec/json/geometry.cpp
+++ b/src/airmap/codec/json/geometry.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  geometry.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/geometry.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/geometry.h
+++ b/src/airmap/codec/json/geometry.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  geometry.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_GEOMETRY_H_
 #define AIRMAP_CODEC_JSON_GEOMETRY_H_
 

--- a/src/airmap/codec/json/get.h
+++ b/src/airmap/codec/json/get.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  get.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_GET_H_
 #define AIRMAP_CODEC_JSON_GET_H_
 

--- a/src/airmap/codec/json/optional.h
+++ b/src/airmap/codec/json/optional.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  optional.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_OPTIONAL_H_
 #define AIRMAP_CODEC_JSON_OPTIONAL_H_
 

--- a/src/airmap/codec/json/pilot.cpp
+++ b/src/airmap/codec/json/pilot.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilot.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/pilot.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/pilot.h
+++ b/src/airmap/codec/json/pilot.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilot.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_PILOT_H_
 #define AIRMAP_CODEC_JSON_PILOT_H_
 

--- a/src/airmap/codec/json/pilots.cpp
+++ b/src/airmap/codec/json/pilots.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/pilots.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/pilots.h
+++ b/src/airmap/codec/json/pilots.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_PILOTS_H_
 #define AIRMAP_CODEC_JSON_PILOTS_H_
 

--- a/src/airmap/codec/json/rule.cpp
+++ b/src/airmap/codec/json/rule.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rule.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/rule.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/rule.h
+++ b/src/airmap/codec/json/rule.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rule.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_RULE_H_
 #define AIRMAP_CODEC_JSON_RULE_H_
 

--- a/src/airmap/codec/json/ruleset.cpp
+++ b/src/airmap/codec/json/ruleset.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  ruleset.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/ruleset.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/ruleset.h
+++ b/src/airmap/codec/json/ruleset.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  ruleset.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_RULESET_H_
 #define AIRMAP_CODEC_JSON_RULESET_H_
 

--- a/src/airmap/codec/json/rulesets.cpp
+++ b/src/airmap/codec/json/rulesets.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec.h>
 #include <airmap/codec/json/geometry.h>
 #include <airmap/codec/json/get.h>

--- a/src/airmap/codec/json/rulesets.h
+++ b/src/airmap/codec/json/rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_RULESETS_H_
 #define AIRMAP_CODEC_JSON_RULESETS_H_
 

--- a/src/airmap/codec/json/status.cpp
+++ b/src/airmap/codec/json/status.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/status.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/status.h
+++ b/src/airmap/codec/json/status.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_STATUS_H_
 #define AIRMAP_CODEC_JSON_STATUS_H_
 

--- a/src/airmap/codec/json/token.cpp
+++ b/src/airmap/codec/json/token.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  token.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/token.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/token.h
+++ b/src/airmap/codec/json/token.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  token.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_TOKEN_H_
 #define AIRMAP_CODEC_JSON_TOKEN_H_
 

--- a/src/airmap/codec/json/traffic.cpp
+++ b/src/airmap/codec/json/traffic.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/codec/json/traffic.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/codec/json/traffic.h
+++ b/src/airmap/codec/json/traffic.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CODEC_JSON_TRAFFIC_H_
 #define AIRMAP_CODEC_JSON_TRAFFIC_H_
 

--- a/src/airmap/context.cpp
+++ b/src/airmap/context.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  context.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/context.h>
 
 #include <airmap/boost/context.h>

--- a/src/airmap/credentials.cpp
+++ b/src/airmap/credentials.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  credentials.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/credentials.h>
 
 std::istream& airmap::operator>>(std::istream& in, Credentials::Type& type) {

--- a/src/airmap/date_time.cpp
+++ b/src/airmap/date_time.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  date_time.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/date_time.h>
 
 #include <boost/date_time.hpp>

--- a/src/airmap/error.cpp
+++ b/src/airmap/error.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  error.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/error.h>
 
 #include <cassert>

--- a/src/airmap/evaluation.cpp
+++ b/src/airmap/evaluation.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  evaluation.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/evaluation.h>
 
 #include <iostream>

--- a/src/airmap/geometry.cpp
+++ b/src/airmap/geometry.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  geometry.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/geometry.h>
 
 airmap::Geometry::Geometry() : type_{Type::invalid} {

--- a/src/airmap/grpc/client/executor.cpp
+++ b/src/airmap/grpc/client/executor.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  executor.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/grpc/client/executor.h>
 
 #include <airmap/grpc/method_invocation.h>

--- a/src/airmap/grpc/client/executor.h
+++ b/src/airmap/grpc/client/executor.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  executor.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GRPC_CLIENT_EXECUTOR_H_
 #define AIRMAP_GRPC_CLIENT_EXECUTOR_H_
 

--- a/src/airmap/grpc/init.cpp
+++ b/src/airmap/grpc/init.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  init.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/grpc/init.h>
 
 #include <grpc++/grpc++.h>

--- a/src/airmap/grpc/init.h
+++ b/src/airmap/grpc/init.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  init.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GRPC_INIT_H_
 #define AIRMAP_GRPC_INIT_H_
 

--- a/src/airmap/grpc/method_invocation.cpp
+++ b/src/airmap/grpc/method_invocation.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  method_invocation.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/grpc/method_invocation.h>
 
 #include <iostream>

--- a/src/airmap/grpc/method_invocation.h
+++ b/src/airmap/grpc/method_invocation.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  method_invocation.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GRPC_METHOD_INVICATION_H_
 #define AIRMAP_GRPC_METHOD_INVICATION_H_
 

--- a/src/airmap/grpc/server/executor.cpp
+++ b/src/airmap/grpc/server/executor.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  executor.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/grpc/server/executor.h>
 
 #include <airmap/grpc/method_invocation.h>

--- a/src/airmap/grpc/server/executor.h
+++ b/src/airmap/grpc/server/executor.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  executor.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GRPC_SERVER_EXECUTOR_H_
 #define AIRMAP_GRPC_SERVER_EXECUTOR_H_
 

--- a/src/airmap/grpc/server/service.h
+++ b/src/airmap/grpc/server/service.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  service.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GRPC_SERVER_SERVICE_H_
 #define AIRMAP_GRPC_SERVER_SERVICE_H_
 

--- a/src/airmap/jsend.h
+++ b/src/airmap/jsend.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  jsend.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_JSEND_H_
 #define AIRMAP_JSEND_H_
 

--- a/src/airmap/logger.cpp
+++ b/src/airmap/logger.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  logger.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/logger.h>
 
 #include <airmap/date_time.h>

--- a/src/airmap/mavlink/boost/serial_channel.cpp
+++ b/src/airmap/mavlink/boost/serial_channel.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  serial_channel.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/boost/serial_channel.h>
 
 #include <termios.h>

--- a/src/airmap/mavlink/boost/serial_channel.h
+++ b/src/airmap/mavlink/boost/serial_channel.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  serial_channel.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_BOOST_SERIAL_CHANNEL_H_
 #define AIRMAP_MAVLINK_BOOST_SERIAL_CHANNEL_H_
 

--- a/src/airmap/mavlink/boost/tcp_channel.cpp
+++ b/src/airmap/mavlink/boost/tcp_channel.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  tcp_channel.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/boost/tcp_channel.h>
 
 namespace {

--- a/src/airmap/mavlink/boost/tcp_channel.h
+++ b/src/airmap/mavlink/boost/tcp_channel.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  tcp_channel.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_BOOST_TCP_CHANNEL_H_
 #define AIRMAP_MAVLINK_BOOST_TCP_CHANNEL_H_
 

--- a/src/airmap/mavlink/boost/tcp_route.cpp
+++ b/src/airmap/mavlink/boost/tcp_route.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  tcp_route.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/boost/tcp_route.h>
 
 namespace {

--- a/src/airmap/mavlink/boost/tcp_route.h
+++ b/src/airmap/mavlink/boost/tcp_route.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  tcp_route.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_BOOST_TCP_ROUTE_H_
 #define AIRMAP_MAVLINK_BOOST_TCP_ROUTE_H_
 

--- a/src/airmap/mavlink/boost/udp_channel.cpp
+++ b/src/airmap/mavlink/boost/udp_channel.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  udp_channel.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/boost/udp_channel.h>
 
 namespace {

--- a/src/airmap/mavlink/boost/udp_channel.h
+++ b/src/airmap/mavlink/boost/udp_channel.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  udp_channel.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_BOOST_UDP_CHANNEL_H_
 #define AIRMAP_MAVLINK_BOOST_UDP_CHANNEL_H_
 

--- a/src/airmap/mavlink/channel.cpp
+++ b/src/airmap/mavlink/channel.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  channel.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/channel.h>
 
 #include <iostream>

--- a/src/airmap/mavlink/channel.h
+++ b/src/airmap/mavlink/channel.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  channel.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_CHANNEL_H_
 #define AIRMAP_MAVLINK_CHANNEL_H_
 

--- a/src/airmap/mavlink/global_position_int.cpp
+++ b/src/airmap/mavlink/global_position_int.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  global_position_int.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/global_position_int.h>
 
 #include <iostream>

--- a/src/airmap/mavlink/global_position_int.h
+++ b/src/airmap/mavlink/global_position_int.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  global_position_int.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_GLOBAL_POSITION_INT_H_
 #define AIRMAP_MAVLINK_GLOBAL_POSITION_INT_H_
 

--- a/src/airmap/mavlink/heartbeat.cpp
+++ b/src/airmap/mavlink/heartbeat.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  heartbeat.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/heartbeat.h>
 
 #include <iostream>

--- a/src/airmap/mavlink/heartbeat.h
+++ b/src/airmap/mavlink/heartbeat.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  heartbeat.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_HEARTBEAT_H_
 #define AIRMAP_MAVLINK_HEARTBEAT_H_
 

--- a/src/airmap/mavlink/mission.cpp
+++ b/src/airmap/mavlink/mission.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  mission.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/mission.h>
 
 bool airmap::mavlink::Mission::update(const mavlink_message_t& msg) {

--- a/src/airmap/mavlink/mission.h
+++ b/src/airmap/mavlink/mission.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  mission.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_MISSION_H_
 #define AIRMAP_MAVLINK_MISSION_H_
 

--- a/src/airmap/mavlink/router.cpp
+++ b/src/airmap/mavlink/router.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  router.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/router.h>
 
 airmap::mavlink::Router::Router(const std::initializer_list<std::shared_ptr<Route>>& routes) : routes_{routes} {

--- a/src/airmap/mavlink/router.h
+++ b/src/airmap/mavlink/router.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  router.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_ROUTER_H_
 #define AIRMAP_MAVLINK_ROUTER_H_
 

--- a/src/airmap/mavlink/state.cpp
+++ b/src/airmap/mavlink/state.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  state.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/state.h>
 
 #include <iostream>

--- a/src/airmap/mavlink/state.h
+++ b/src/airmap/mavlink/state.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  state.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_STATE_H_
 #define AIRMAP_MAVLINK_STATE_H_
 

--- a/src/airmap/mavlink/vehicle.cpp
+++ b/src/airmap/mavlink/vehicle.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  vehicle.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/vehicle.h>
 
 #include <common/mavlink_msg_global_position_int.h>

--- a/src/airmap/mavlink/vehicle.h
+++ b/src/airmap/mavlink/vehicle.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  vehicle.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_VEHICLE_H_
 #define AIRMAP_MAVLINK_VEHICLE_H_
 

--- a/src/airmap/mavlink/vehicle_tracker.cpp
+++ b/src/airmap/mavlink/vehicle_tracker.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  vehicle_tracker.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/mavlink/vehicle_tracker.h>
 
 void airmap::mavlink::VehicleTracker::update(const mavlink_message_t& msg) {

--- a/src/airmap/mavlink/vehicle_tracker.h
+++ b/src/airmap/mavlink/vehicle_tracker.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  vehicle_tracker.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MAVLINK_VEHICLE_TRACKER_H_
 #define AIRMAP_MAVLINK_VEHICLE_TRACKER_H_
 

--- a/src/airmap/monitor/daemon.cpp
+++ b/src/airmap/monitor/daemon.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  daemon.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/monitor/daemon.h>
 #include <airmap/monitor/submitting_vehicle_monitor.h>
 

--- a/src/airmap/monitor/daemon.h
+++ b/src/airmap/monitor/daemon.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  daemon.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_DAEMON_H_
 #define AIRMAP_MONITOR_DAEMON_H_
 

--- a/src/airmap/monitor/fan_out_traffic_monitor.cpp
+++ b/src/airmap/monitor/fan_out_traffic_monitor.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  fan_out_traffic_monitor.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/monitor/fan_out_traffic_monitor.h>
 
 void airmap::monitor::FanOutTrafficMonitor::subscribe(const std::shared_ptr<Traffic::Monitor::Subscriber>& subscriber) {

--- a/src/airmap/monitor/fan_out_traffic_monitor.h
+++ b/src/airmap/monitor/fan_out_traffic_monitor.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  fan_out_traffic_monitor.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_FAN_OUT_TRAFFIC_MONITOR_H_
 #define AIRMAP_MONITOR_FAN_OUT_TRAFFIC_MONITOR_H_
 

--- a/src/airmap/monitor/grpc/client.cpp
+++ b/src/airmap/monitor/grpc/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/monitor/grpc/client.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/monitor/grpc/client.h
+++ b/src/airmap/monitor/grpc/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_GRPC_CLIENT_H_
 #define AIRMAP_MONITOR_GRPC_CLIENT_H_
 

--- a/src/airmap/monitor/grpc/service.cpp
+++ b/src/airmap/monitor/grpc/service.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  service.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/monitor/grpc/service.h>
 
 #include <airmap/codec/grpc/traffic.h>

--- a/src/airmap/monitor/grpc/service.h
+++ b/src/airmap/monitor/grpc/service.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  service.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_GRPC_SERVICE_H_
 #define AIRMAP_MONITOR_GRPC_SERVICE_H_
 

--- a/src/airmap/monitor/submitting_vehicle_monitor.cpp
+++ b/src/airmap/monitor/submitting_vehicle_monitor.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  submitting_vehicle_monitor.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/monitor/submitting_vehicle_monitor.h>
 
 airmap::monitor::SubmittingVehicleMonitor::SubmittingVehicleMonitor(

--- a/src/airmap/monitor/submitting_vehicle_monitor.h
+++ b/src/airmap/monitor/submitting_vehicle_monitor.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  submitting_vehicle_monitor.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_SUBMITTING_VEHICLE_MONITOR_H_
 #define AIRMAP_MONITOR_SUBMITTING_VEHICLE_MONITOR_H_
 

--- a/src/airmap/monitor/telemetry_submitter.cpp
+++ b/src/airmap/monitor/telemetry_submitter.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry_submitter.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/monitor/telemetry_submitter.h>
 
 #include <boost/uuid/uuid.hpp>

--- a/src/airmap/monitor/telemetry_submitter.h
+++ b/src/airmap/monitor/telemetry_submitter.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry_submitter.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_TELEMETRY_SUBMITTER_H_
 #define AIRMAP_MONITOR_TELEMETRY_SUBMITTER_H_
 

--- a/src/airmap/net/http/boost/request.cpp
+++ b/src/airmap/net/http/boost/request.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  request.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/http/boost/request.h>
 
 namespace asio = boost::asio;

--- a/src/airmap/net/http/boost/request.h
+++ b/src/airmap/net/http/boost/request.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  request.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_BOOST_REQUEST_H_
 #define AIRMAP_NET_HTTP_BOOST_REQUEST_H_
 

--- a/src/airmap/net/http/boost/requester.cpp
+++ b/src/airmap/net/http/boost/requester.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  requester.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/http/boost/request.h>
 
 #include <airmap/net/http/boost/requester.h>

--- a/src/airmap/net/http/boost/requester.h
+++ b/src/airmap/net/http/boost/requester.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  requester.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_BOOST_REQUESTER_H_
 #define AIRMAP_NET_HTTP_BOOST_REQUESTER_H_
 

--- a/src/airmap/net/http/middleware.h
+++ b/src/airmap/net/http/middleware.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  middleware.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_MIDDLEWARE_H_
 #define AIRMAP_NET_HTTP_MIDDLEWARE_H_
 

--- a/src/airmap/net/http/request.h
+++ b/src/airmap/net/http/request.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  request.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_REQUEST_H_
 #define AIRMAP_NET_HTTP_REQUEST_H_
 

--- a/src/airmap/net/http/requester.cpp
+++ b/src/airmap/net/http/requester.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  requester.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/http/requester.h>
 
 #include <boost/uuid/uuid.hpp>

--- a/src/airmap/net/http/requester.h
+++ b/src/airmap/net/http/requester.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  requester.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_REQUESTER_H_
 #define AIRMAP_NET_HTTP_REQUESTER_H_
 

--- a/src/airmap/net/http/requester_with_api_key.cpp
+++ b/src/airmap/net/http/requester_with_api_key.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  requester_with_api_key.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/http/requester_with_api_key.h>
 
 airmap::net::http::RequesterWithApiKey::RequesterWithApiKey(const std::string& api_key,

--- a/src/airmap/net/http/requester_with_api_key.h
+++ b/src/airmap/net/http/requester_with_api_key.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  requester_with_api_key.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_REQUESTER_WITH_API_KEY_H_
 #define AIRMAP_NET_HTTP_REQUESTER_WITH_API_KEY_H_
 

--- a/src/airmap/net/http/response.cpp
+++ b/src/airmap/net/http/response.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  response.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/http/response.h>
 
 // classify returns the Classification of the status of this response.

--- a/src/airmap/net/http/response.h
+++ b/src/airmap/net/http/response.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  response.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_RESPONSE_H_
 #define AIRMAP_NET_HTTP_RESPONSE_H_
 

--- a/src/airmap/net/http/user_agent.cpp
+++ b/src/airmap/net/http/user_agent.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  user_agent.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/http/user_agent.h>
 
 #include <airmap/util/fmt.h>

--- a/src/airmap/net/http/user_agent.h
+++ b/src/airmap/net/http/user_agent.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  user_agent.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_HTTP_USER_AGENT_H_
 #define AIRMAP_NET_HTTP_USER_AGENT_H_
 

--- a/src/airmap/net/mqtt/boost/broker.cpp
+++ b/src/airmap/net/mqtt/boost/broker.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  broker.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/mqtt/boost/broker.h>
 
 #include <airmap/net/mqtt/boost/client.h>

--- a/src/airmap/net/mqtt/boost/broker.h
+++ b/src/airmap/net/mqtt/boost/broker.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  broker.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_MQTT_BOOST_BROKER_H_
 #define AIRMAP_NET_MQTT_BOOST_BROKER_H_
 

--- a/src/airmap/net/mqtt/boost/client.cpp
+++ b/src/airmap/net/mqtt/boost/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/mqtt/boost/client.h>
 
 #include <mqtt/str_connect_return_code.hpp>

--- a/src/airmap/net/mqtt/boost/client.h
+++ b/src/airmap/net/mqtt/boost/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_MQTT_BOOST_CLIENT_H_
 #define AIRMAP_NET_MQTT_BOOST_CLIENT_H_
 

--- a/src/airmap/net/mqtt/broker.h
+++ b/src/airmap/net/mqtt/broker.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  broker.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_MQTT_BROKER_H_
 #define AIRMAP_NET_MQTT_BROKER_H_
 

--- a/src/airmap/net/mqtt/client.h
+++ b/src/airmap/net/mqtt/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_MQTT_CLIENT_H_
 #define AIRMAP_NET_MQTT_CLIENT_H_
 

--- a/src/airmap/net/udp/boost/sender.cpp
+++ b/src/airmap/net/udp/boost/sender.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  sender.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/net/udp/boost/sender.h>
 
 #include <airmap/util/fmt.h>

--- a/src/airmap/net/udp/boost/sender.h
+++ b/src/airmap/net/udp/boost/sender.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  sender.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_UDP_BOOST_SENDER_H_
 #define AIRMAP_NET_UDP_BOOST_SENDER_H_
 

--- a/src/airmap/net/udp/sender.h
+++ b/src/airmap/net/udp/sender.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  sender.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_NET_UDP_SENDER_H_
 #define AIRMAP_NET_UDP_SENDER_H_
 

--- a/src/airmap/paths.cpp
+++ b/src/airmap/paths.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  paths.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/paths.h>
 
 #include <airmap/platform/interface.h>

--- a/src/airmap/paths.h
+++ b/src/airmap/paths.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  paths.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PATHS_H_
 #define AIRMAP_PATHS_H_
 

--- a/src/airmap/pilots.cpp
+++ b/src/airmap/pilots.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/pilots.h>
 
 #include <iostream>

--- a/src/airmap/platform/interface.cpp
+++ b/src/airmap/platform/interface.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  interface.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/interface.h>
 
 #if defined(AIRMAP_PLATFORM_LINUX)

--- a/src/airmap/platform/interface.h
+++ b/src/airmap/platform/interface.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  interface.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_INTERFACE_H_
 #define AIRMAP_PLATFORM_INTERFACE_H_
 

--- a/src/airmap/platform/linux/interface.cpp
+++ b/src/airmap/platform/linux/interface.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  interface.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/linux/interface.h>
 
 airmap::platform::StandardPaths& airmap::platform::linux_::Interface::standard_paths() {

--- a/src/airmap/platform/linux/interface.h
+++ b/src/airmap/platform/linux/interface.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  interface.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_LINUX_INTERFACE_H_
 #define AIRMAP_PLATFORM_LINUX_INTERFACE_H_
 

--- a/src/airmap/platform/linux/standard_paths.cpp
+++ b/src/airmap/platform/linux/standard_paths.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  standard_paths.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/linux/standard_paths.h>
 
 #include <airmap/platform/linux/xdg.h>

--- a/src/airmap/platform/linux/standard_paths.h
+++ b/src/airmap/platform/linux/standard_paths.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  standard_paths.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_LINUX_STANDARD_PATHS_H_
 #define AIRMAP_PLATFORM_LINUX_STANDARD_PATHS_H_
 

--- a/src/airmap/platform/linux/xdg.cpp
+++ b/src/airmap/platform/linux/xdg.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  xdg.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/linux/xdg.h>
 
 #include <boost/algorithm/string.hpp>

--- a/src/airmap/platform/linux/xdg.h
+++ b/src/airmap/platform/linux/xdg.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  xdg.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_LINUX_XDG_H_
 #define AIRMAP_PLATFORM_LINUX_XDG_H_
 

--- a/src/airmap/platform/null/interface.cpp
+++ b/src/airmap/platform/null/interface.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  interface.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/null/interface.h>
 
 airmap::platform::StandardPaths& airmap::platform::null::Interface::standard_paths() {

--- a/src/airmap/platform/null/interface.h
+++ b/src/airmap/platform/null/interface.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  interface.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_NULL_INTERFACE_H_
 #define AIRMAP_PLATFORM_NULL_INTERFACE_H_
 

--- a/src/airmap/platform/null/standard_paths.cpp
+++ b/src/airmap/platform/null/standard_paths.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  standard_paths.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/null/standard_paths.h>
 
 airmap::Optional<airmap::platform::Path> airmap::platform::null::StandardPaths::path(Scope scope, Location location) {

--- a/src/airmap/platform/null/standard_paths.h
+++ b/src/airmap/platform/null/standard_paths.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  standard_paths.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_NULL_STANDARD_PATHS_H_
 #define AIRMAP_PLATFORM_NULL_STANDARD_PATHS_H_
 

--- a/src/airmap/platform/path.h
+++ b/src/airmap/platform/path.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  path.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_PATH_H_
 #define AIRMAP_PLATFORM_PATH_H_
 

--- a/src/airmap/platform/standard_paths.cpp
+++ b/src/airmap/platform/standard_paths.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  standard_paths.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/platform/standard_paths.h>
 
 #include <iostream>

--- a/src/airmap/platform/standard_paths.h
+++ b/src/airmap/platform/standard_paths.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  standard_paths.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PLATFORM_STANDARD_PATHS_H_
 #define AIRMAP_PLATFORM_STANDARD_PATHS_H_
 

--- a/src/airmap/qt/advisory.cpp
+++ b/src/airmap/qt/advisory.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/advisory.h>
 
 std::shared_ptr<airmap::qt::Advisory> airmap::qt::Advisory::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/advisory.h
+++ b/src/airmap/qt/advisory.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_ADVISORY_H_
 #define AIRMAP_QT_ADVISORY_H_
 

--- a/src/airmap/qt/aircrafts.cpp
+++ b/src/airmap/qt/aircrafts.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/aircrafts.h>
 
 std::shared_ptr<airmap::qt::Aircrafts> airmap::qt::Aircrafts::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/aircrafts.h
+++ b/src/airmap/qt/aircrafts.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_AIRCRAFTS_H_
 #define AIRMAP_QT_AIRCRAFTS_H_
 

--- a/src/airmap/qt/airspaces.cpp
+++ b/src/airmap/qt/airspaces.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/airspaces.h>
 
 std::shared_ptr<airmap::qt::Airspaces> airmap::qt::Airspaces::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/airspaces.h
+++ b/src/airmap/qt/airspaces.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_AIRSPACES_H_
 #define AIRMAP_QT_AIRSPACES_H_
 

--- a/src/airmap/qt/authenticator.cpp
+++ b/src/airmap/qt/authenticator.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/authenticator.h>
 
 std::shared_ptr<airmap::qt::Authenticator> airmap::qt::Authenticator::create(

--- a/src/airmap/qt/authenticator.h
+++ b/src/airmap/qt/authenticator.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_AUTHENTICATOR_H_
 #define AIRMAP_QT_AUTHENTICATOR_H_
 

--- a/src/airmap/qt/client.cpp
+++ b/src/airmap/qt/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/client.h>
 
 #include <airmap/qt/dispatcher.h>

--- a/src/airmap/qt/dispatcher.cpp
+++ b/src/airmap/qt/dispatcher.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  dispatcher.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/dispatcher.h>
 
 #include <QCoreApplication>

--- a/src/airmap/qt/dispatcher.h
+++ b/src/airmap/qt/dispatcher.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  dispatcher.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_DISPATCHER_H_
 #define AIRMAP_QT_DISPATCHER_H_
 

--- a/src/airmap/qt/flight_plans.cpp
+++ b/src/airmap/qt/flight_plans.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/flight_plans.h>
 
 std::shared_ptr<airmap::qt::FlightPlans> airmap::qt::FlightPlans::create(

--- a/src/airmap/qt/flight_plans.h
+++ b/src/airmap/qt/flight_plans.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_FLIGHT_PLANS_H_
 #define AIRMAP_QT_FLIGHT_PLANS_H_
 

--- a/src/airmap/qt/flights.cpp
+++ b/src/airmap/qt/flights.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/flights.h>
 
 std::shared_ptr<airmap::qt::Flights> airmap::qt::Flights::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/flights.h
+++ b/src/airmap/qt/flights.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_FLIGHTS_H_
 #define AIRMAP_QT_FLIGHTS_H_
 

--- a/src/airmap/qt/logger.cpp
+++ b/src/airmap/qt/logger.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  logger.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/logger.h>
 
 #include <airmap/qt/dispatcher.h>

--- a/src/airmap/qt/pilots.cpp
+++ b/src/airmap/qt/pilots.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/pilots.h>
 
 std::shared_ptr<airmap::qt::Pilots> airmap::qt::Pilots::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/pilots.h
+++ b/src/airmap/qt/pilots.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_PILOTS_H_
 #define AIRMAP_QT_PILOTS_H_
 

--- a/src/airmap/qt/rulesets.cpp
+++ b/src/airmap/qt/rulesets.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/rulesets.h>
 
 std::shared_ptr<airmap::qt::RuleSets> airmap::qt::RuleSets::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/rulesets.h
+++ b/src/airmap/qt/rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_RULESETS_H_
 #define AIRMAP_QT_RULESETS_H_
 

--- a/src/airmap/qt/status.cpp
+++ b/src/airmap/qt/status.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/status.h>
 
 std::shared_ptr<airmap::qt::Status> airmap::qt::Status::create(const std::shared_ptr<Dispatcher>& dispatcher,

--- a/src/airmap/qt/status.h
+++ b/src/airmap/qt/status.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_STATUS_H_
 #define AIRMAP_QT_STATUS_H_
 

--- a/src/airmap/qt/telemetry.cpp
+++ b/src/airmap/qt/telemetry.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/telemetry.h>
 
 #include <airmap/flight.h>

--- a/src/airmap/qt/telemetry.h
+++ b/src/airmap/qt/telemetry.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_TELEMETRY_H_
 #define AIRMAP_QT_TELEMETRY_H_
 

--- a/src/airmap/qt/traffic.cpp
+++ b/src/airmap/qt/traffic.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/traffic.h>
 
 std::shared_ptr<airmap::qt::Traffic::Monitor> airmap::qt::Traffic::Monitor::create(

--- a/src/airmap/qt/traffic.h
+++ b/src/airmap/qt/traffic.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_TRAFFIC_H_
 #define AIRMAP_QT_TRAFFIC_H_
 

--- a/src/airmap/qt/types.cpp
+++ b/src/airmap/qt/types.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  types.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/qt/types.h>
 
 namespace {

--- a/src/airmap/rest/advisory.cpp
+++ b/src/airmap/rest/advisory.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/advisory.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/advisory.h
+++ b/src/airmap/rest/advisory.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  advisory.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_ADVISORY_H_
 #define AIRMAP_REST_ADVISORY_H_
 

--- a/src/airmap/rest/aircrafts.cpp
+++ b/src/airmap/rest/aircrafts.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/aircrafts.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/aircrafts.h
+++ b/src/airmap/rest/aircrafts.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  aircrafts.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_AIRCRAFTS_H_
 #define AIRMAP_REST_AIRCRAFTS_H_
 

--- a/src/airmap/rest/airspaces.cpp
+++ b/src/airmap/rest/airspaces.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/airspaces.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/airspaces.h
+++ b/src/airmap/rest/airspaces.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspaces.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_AIRSPACES_H_
 #define AIRMAP_REST_AIRSPACES_H_
 

--- a/src/airmap/rest/authenticator.cpp
+++ b/src/airmap/rest/authenticator.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/authenticator.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/authenticator.h
+++ b/src/airmap/rest/authenticator.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  authenticator.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_AUTHENTICATOR_H_
 #define AIRMAP_REST_AUTHENTICATOR_H_
 

--- a/src/airmap/rest/client.cpp
+++ b/src/airmap/rest/client.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/client.h>
 
 airmap::rest::Client::Client(const Configuration& configuration, const std::shared_ptr<Context>& parent,

--- a/src/airmap/rest/client.h
+++ b/src/airmap/rest/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_CLIENT_H_
 #define AIRMAP_REST_CLIENT_H_
 

--- a/src/airmap/rest/flight_plans.cpp
+++ b/src/airmap/rest/flight_plans.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/flight_plans.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/flight_plans.h
+++ b/src/airmap/rest/flight_plans.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flight_plans.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_FLIGHT_PLANS_H_
 #define AIRMAP_REST_FLIGHT_PLANS_H_
 

--- a/src/airmap/rest/flights.cpp
+++ b/src/airmap/rest/flights.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/flights.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/flights.h
+++ b/src/airmap/rest/flights.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  flights.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_FLIGHTS_H_
 #define AIRMAP_REST_FLIGHTS_H_
 

--- a/src/airmap/rest/pilots.cpp
+++ b/src/airmap/rest/pilots.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/pilots.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/pilots.h
+++ b/src/airmap/rest/pilots.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  pilots.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_PILOTS_H_
 #define AIRMAP_REST_PILOTS_H_
 

--- a/src/airmap/rest/rulesets.cpp
+++ b/src/airmap/rest/rulesets.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/rulesets.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/rulesets.h
+++ b/src/airmap/rest/rulesets.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rulesets.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_RULESETS_H_
 #define AIRMAP_REST_RULESETS_H_
 

--- a/src/airmap/rest/status.cpp
+++ b/src/airmap/rest/status.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/status.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/status.h
+++ b/src/airmap/rest/status.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_STATUS_H_
 #define AIRMAP_REST_STATUS_H_
 

--- a/src/airmap/rest/telemetry.cpp
+++ b/src/airmap/rest/telemetry.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/telemetry.h>
 
 #include <airmap/flight.h>

--- a/src/airmap/rest/telemetry.h
+++ b/src/airmap/rest/telemetry.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_TELEMETRY_H_
 #define AIRMAP_REST_TELEMETRY_H_
 

--- a/src/airmap/rest/traffic.cpp
+++ b/src/airmap/rest/traffic.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/traffic.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/rest/traffic.h
+++ b/src/airmap/rest/traffic.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_REST_TRAFFIC_H_
 #define AIRMAP_REST_TRAFFIC_H_
 

--- a/src/airmap/rule.cpp
+++ b/src/airmap/rule.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rule.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rule.h>
 
 bool airmap::operator==(const Rule& lhs, const Rule& rhs) {

--- a/src/airmap/ruleset.cpp
+++ b/src/airmap/ruleset.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  ruleset.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/ruleset.h>
 
 #include <iostream>

--- a/src/airmap/status.cpp
+++ b/src/airmap/status.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  status.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/status.h>
 
 #include <iosfwd>

--- a/src/airmap/telemetry.cpp
+++ b/src/airmap/telemetry.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/telemetry.h>
 
 airmap::Telemetry::Update::Update(const Position& position) : type_{Type::position} {

--- a/src/airmap/token.cpp
+++ b/src/airmap/token.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  token.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/token.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/traffic.cpp
+++ b/src/airmap/traffic.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  traffic.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/traffic.h>
 
 #include <airmap/util/formatting_logger.h>

--- a/src/airmap/util/cheap_ruler.cpp
+++ b/src/airmap/util/cheap_ruler.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  cheap_ruler.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/util/cheap_ruler.h>
 
 airmap::util::CheapRuler::CheapRuler(double latitude) {

--- a/src/airmap/util/cheap_ruler.h
+++ b/src/airmap/util/cheap_ruler.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  cheap_ruler.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_UTIL_CHEAP_RULER_H_
 #define AIRMAP_UTIL_CHEAP_RULER_H_
 

--- a/src/airmap/util/cli.cpp
+++ b/src/airmap/util/cli.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  cli.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 /*
  * Copyright (C) 2016 Canonical, Ltd.
  * Copyright (C) 2017 AirMap Inc.

--- a/src/airmap/util/cli.h
+++ b/src/airmap/util/cli.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  cli.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 /*
  * Copyright (C) 2016 Canonical, Ltd.
  * Copyright (C) 2017 AirMap Inc.

--- a/src/airmap/util/fmt.h
+++ b/src/airmap/util/fmt.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  fmt.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_UTIL_FMT_H_
 #define AIRMAP_UTIL_FMT_H_
 

--- a/src/airmap/util/formatting_logger.h
+++ b/src/airmap/util/formatting_logger.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  formatting_logger.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_UTIL_FORMATTING_LOGGER_H_
 #define AIRMAP_UTIL_FORMATTING_LOGGER_H_
 

--- a/src/airmap/util/scenario_simulator.cpp
+++ b/src/airmap/util/scenario_simulator.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  scenario_simulator.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/util/scenario_simulator.h>
 
 #include <airmap/codec.h>

--- a/src/airmap/util/scenario_simulator.h
+++ b/src/airmap/util/scenario_simulator.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  scenario_simulator.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_UTIL_SCENARIO_SIMULATOR_H_
 #define AIRMAP_UTIL_SCENARIO_SIMULATOR_H_
 

--- a/src/airmap/util/tagged_string.h
+++ b/src/airmap/util/tagged_string.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  tagged_string.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_UTIL_TAGGED_STRING_H_
 #define AIRMAP_UTIL_TAGGED_STRING_H_
 

--- a/src/airmap/util/telemetry_simulator.cpp
+++ b/src/airmap/util/telemetry_simulator.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry_simulator.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/util/telemetry_simulator.h>
 
 #include <algorithm>

--- a/src/airmap/util/telemetry_simulator.h
+++ b/src/airmap/util/telemetry_simulator.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry_simulator.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_UTIL_TELEMETRY_SIMULATOR_H_
 #define AIRMAP_UTIL_TELEMETRY_SIMULATOR_H_
 

--- a/test/airspace_test.cpp
+++ b/test/airspace_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  airspace_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE airspace
 
 #include <airmap/airspace.h>

--- a/test/cli_test.cpp
+++ b/test/cli_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  cli_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE cli
 
 #include <airmap/util/cli.h>

--- a/test/client_test.cpp
+++ b/test/client_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE client
 
 #include <helper.h>

--- a/test/credentials_test.cpp
+++ b/test/credentials_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  credentials_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE credentials
 
 #include <airmap/credentials.h>

--- a/test/daemon_test.cpp
+++ b/test/daemon_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  daemon_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE daemon
 
 #include <airmap/boost/context.h>

--- a/test/datetime_test.cpp
+++ b/test/datetime_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  datetime_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE datetime
 
 #include <airmap/date_time.h>

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  error_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE error
 
 #include <airmap/error.h>

--- a/test/geometry_test.cpp
+++ b/test/geometry_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  geometry_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE geometry
 
 #include <airmap/geometry.h>

--- a/test/helper.h
+++ b/test/helper.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  helper.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef TEST_HELPER_H_
 #define TEST_HELPER_H_
 

--- a/test/issue_38_test.cpp
+++ b/test/issue_38_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  issue_38_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE issue_38
 
 #include <airmap/airspace.h>

--- a/test/mock/client.h
+++ b/test/mock/client.h
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  client.h
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef MOCK_CLIENT_H_
 #define MOCK_CLIENT_H_
 

--- a/test/platform_test.cpp
+++ b/test/platform_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  platform_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE platform
 
 #include <airmap/platform/interface.h>

--- a/test/rest_test.cpp
+++ b/test/rest_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  rest_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE rest
 
 #include <airmap/net/http/requester.h>

--- a/test/telemetry_test.cpp
+++ b/test/telemetry_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  telemetry_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include <airmap/rest/telemetry.h>
 
 #include <boost/beast/core/detail/base64.hpp>

--- a/test/token_test.cpp
+++ b/test/token_test.cpp
@@ -1,10 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
 //
-//  token_test.cpp
-//  AirMap Platform SDK
-//
-//  Copyright © 2018 AirMap, Inc. All rights reserved.
-//
-
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define BOOST_TEST_MODULE token
 
 #include <airmap/token.h>


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
This change iterates over all source code files in the repository and unifies license headers. I used a script to do so:
```{bash}
#!/bin/bash

set -e

function adjust_license() {
    header=$(cat <<-EOM
// AirMap Platform SDK
// Copyright © 2018 AirMap, Inc. All rights reserved.
//
// Licensed under the Apache License, Version 2.0 (the License);
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//   http://www.apache.org/licenses/LICENSE-2.0
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an AS IS BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.
EOM
)
    content=$(tail -n +8 "$1")
    echo "${header}"  > "$1"
    echo "${content}" >> "$1"
}

headers=$(find include/airmap -name '*.h')

for header in ${headers}; do
    adjust_license "$header"
done

srcs=$(find src/airmap -name '*.cpp' -o -name '*.h' -not -path 'src/airmap/pregenerated/*')

for src in ${srcs}; do
    adjust_license "$src"
done

examples=$(find examples -type f -name '*.cpp' -o -name '*.h')

for example in ${examples}; do
    adjust_license "$example"
done

tests=$(find test -type f -name '*.cpp' -o -name '*.h')

for test in ${tests}; do
    adjust_license "$test"
done
```