### PR TITLE
fix compilation with grpc enabled

### DIFF
--- a/src/airmap/monitor/CMakeLists.txt
+++ b/src/airmap/monitor/CMakeLists.txt
@@ -37,4 +37,5 @@ target_link_libraries(
   airmap-grpc
   airmap-codec-grpc
   airmap-mavlink
+  crypto
 )


### PR DESCRIPTION
I tried to compile using: `cmake -DAIRMAP_ENABLE_GRPC=1 ..` on an Ubuntu 18.04 machine. This gave an undefined reference to `BIO_f_base64` when running `make`. After adding libcrypto, the linking problem was gone.

I do not know if this breaks anything on other platforms.