### PR TITLE
[build] Add initial/experimental centos support

### DIFF
--- a/tools/centos/cleanup.dev.sh
+++ b/tools/centos/cleanup.dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+yum -y update
+
+# Let's remove our build dependencies
+# and be quite aggressive about it.
+yum remove -y \
+  cmake \
+  git \
+  pkg-config \
+  qtbase5-dev \
+  centos-release-scl

--- a/tools/centos/setup.dev.sh
+++ b/tools/centos/setup.dev.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# This setup is considered experimental thus far.
+
+set -ex
+
+yum -y update
+
+# We first satisfy all of our basic build-dependencies
+# before diving deeper and pulling in required build-time
+# components.
+yum install -y \
+  curl \
+  git \
+  cmake \
+  patch \
+  perl \
+  pkg-config \
+  qtbase5-dev \
+  unzip \
+  zlib1g-dev
+
+# Please see https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/
+# for further details.
+yum install -y centos-release-scl
+
+# Select the specific devtoolset version.
+yum install -y devtoolset-7
+
+
+# Download the latest CMake release
+curl -L https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-Linux-x86_64.tar.gz > /usr/local/cmake-3.14.4-Linux-x86_64.tar.gz
+tar -C /usr/local -xf /usr/local/cmake-3.14.4-Linux-x86_64.tar.gz
+export PATH=/usr/local/cmake-3.14.4-Linux-x86_64/bin:${PATH}
+
+# Download the latest golang release
+curl https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz > /usr/local/go1.12.5.linux-amd64.tar.gz
+tar -C /usr/local -xf /usr/local/go1.12.5.linux-amd64.tar.gz
+export PATH=/usr/local/go/bin:${PATH}
+
+# Inject the devtoolset-7 toolchain into the
+# the current session.
+scl enable devtoolset-7 bash


### PR DESCRIPTION
This PR adds experimental support for centos/RHEL-based distributions. Test it out with:
```
tools/centos/setup.dev.sh
mkdir build
cd build
cmake ..
make
```
Please note that no package or container build is enabled, yet. We will tackle that work in a follow-up PR.