### PR TITLE
[boost] Upgrade boost to 1.69.0

### DIFF
--- a/src/airmap/codec/json/flight_plans.cpp
+++ b/src/airmap/codec/json/flight_plans.cpp
@@ -34,7 +34,7 @@ void airmap::codec::json::decode(const nlohmann::json& j, FlightPlans::Create::P
   get(p.pilot.id, j, "pilot_id");
   if (j.count("aircraft_id") > 0) {
     Pilot::Aircraft aircraft;
-    aircraft.id = j["aircraft_id"];
+    get(aircraft.id, j, "aircraft_id");
     p.aircraft.set(aircraft);
   }
   get(p.buffer, j, "buffer");

--- a/vendor/boost/CMakeLists.txt
+++ b/vendor/boost/CMakeLists.txt
@@ -83,8 +83,8 @@ else()
 endif()
 
 ExternalProject_Add(boost
-  URL https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2
-  URL_HASH SHA256=7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7
+  URL https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2
+  URL_HASH SHA256=8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
   BUILD_IN_SOURCE 1
   UPDATE_COMMAND ""
   PATCH_COMMAND ""


### PR DESCRIPTION
Requires the following fix in boost 1_69_0:

Fixed std::string_view detection issue when using clang-cl.