### PR TITLE
bundle up pathfinding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 .DS_Store
 .vscode
 /build*
+mason_packages
+pathfinding

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 option(AIRMAP_ENABLE_NETWORK_TESTS "enable tests requiring network access"       ON)
 option(AIRMAP_ENABLE_GRPC          "Enable libraries/executables requiring gRPC" OFF)
 option(AIRMAP_ENABLE_QT            "Enable libraries/executables requiring Qt5"  OFF)
+option(AIRMAP_ENABLE_PATHFINDING   "Enable Airmap's pathfinding function" OFF)
 
 if (AIRMAP_ENABLE_GRPC)
   add_definitions(-DAIRMAP_ENABLE_GRPC)
@@ -50,3 +51,10 @@ message(STATUS "Enabling platform ${AIRMAP_PLATFORM}")
 
 include(external.cmake)
 include(airmapd.cmake)
+
+if (AIRMAP_ENABLE_PATHFINDING)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} clone --depth 1 https://github.com/airmap/pathfinding.git -b build-lib
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  add_subdirectory(pathfinding/lib)
+endif ()

--- a/src/airmap/codec/json/date_time.h
+++ b/src/airmap/codec/json/date_time.h
@@ -13,9 +13,8 @@
 #ifndef AIRMAP_CODEC_JSON_DATE_TIME_H_
 #define AIRMAP_CODEC_JSON_DATE_TIME_H_
 
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <airmap/date_time.h>
-
-#include <boost/date_time.hpp>
 
 #include <nlohmann/json.hpp>
 

--- a/src/airmap/date_time.cpp
+++ b/src/airmap/date_time.cpp
@@ -12,7 +12,6 @@
 // limitations under the License.
 #include <airmap/date_time.h>
 
-#include <boost/date_time.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <memory>

--- a/vendor/boost/CMakeLists.txt
+++ b/vendor/boost/CMakeLists.txt
@@ -83,8 +83,8 @@ else()
 endif()
 
 ExternalProject_Add(boost
-  URL https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2
-  URL_HASH SHA256=7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7
+  URL https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2
+  URL_HASH SHA256=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
   BUILD_IN_SOURCE 1
   UPDATE_COMMAND ""
   PATCH_COMMAND ""


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
This PR (via cmake option `-DAIRMAP_ENABLE_PATHFINDING=ON`) allows for bundling https://github.com/airmap/pathfinding (for those who have access to it) as a build artefact of `platform-sdk` 

## Related PRs
List related pull requests against other branches:
https://github.com/airmap/pathfinding/pull/14


## Todos
- [x] Tests
- [ ] Documentation


