### PR TITLE
Fix Android xcompile build for boost 1.70

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -58,3 +58,9 @@ jobs:
           command: build
           Dockerfile: docker/centos
           buildContext: "."
+      - task: Docker@2
+        displayName: android
+        inputs:
+          command: build
+          Dockerfile: docker/android
+          buildContext: "."

--- a/docker/android
+++ b/docker/android
@@ -1,0 +1,23 @@
+FROM ubuntu:18.04
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+RUN tools/ubuntu/setup.dev.sh
+RUN tools/android/download-ndk.sh android-ndk-r21d /tmp
+RUN mkdir build
+WORKDIR build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+	-DANDROID_ABI=armeabi-v7a \
+	-DANDROID_PLATFORM=android-21 \
+	-DANDROID_STL=c++_shared \
+	-DANDROID_CPP_FEATURES="rtti exceptions" \
+	-DCMAKE_TOOLCHAIN_FILE=/tmp/android-ndk-r21d/build/cmake/android.toolchain.cmake \
+	..
+RUN make
+RUN make install
+WORKDIR /usr/src/app
+RUN tools/ubuntu/cleanup.dev.sh
+WORKDIR /usr
+RUN rm -rf /usr/src/app

--- a/platform-sdk.creator
+++ b/platform-sdk.creator
@@ -1,0 +1,1 @@
+[General]

--- a/src/airmap/codec/json/flight_plans.cpp
+++ b/src/airmap/codec/json/flight_plans.cpp
@@ -34,7 +34,7 @@ void airmap::codec::json::decode(const nlohmann::json& j, FlightPlans::Create::P
   get(p.pilot.id, j, "pilot_id");
   if (j.count("aircraft_id") > 0) {
     Pilot::Aircraft aircraft;
-    aircraft.id = j["aircraft_id"];
+    get(aircraft.id, j, "aircraft_id");
     p.aircraft.set(aircraft);
   }
   get(p.buffer, j, "buffer");

--- a/tools/android/download-ndk.sh
+++ b/tools/android/download-ndk.sh
@@ -15,6 +15,11 @@ case "${version}" in
         file=android-ndk-r17c-linux-x86_64.zip
         sha1=12cacc70c3fd2f40574015631c00f41fb8a39048
         ;;
+    android-ndk-r21d)
+        url=https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
+        file=android-ndk-r21d-linux-x86_64.zip
+        sha1=bcf4023eb8cb6976a4c7cff0a8a8f145f162bf4d
+        ;;
     *)
         echo "unknown NDK version ${version}"
         exit 1

--- a/vendor/boost/CMakeLists.txt
+++ b/vendor/boost/CMakeLists.txt
@@ -82,12 +82,14 @@ else()
   endif()
 endif()
 
-ExternalProject_Add(boost
+ExternalProject_Add(
+  boost
   URL https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2
   URL_HASH SHA256=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
   BUILD_IN_SOURCE 1
   UPDATE_COMMAND ""
-  PATCH_COMMAND ""
+  PATCH_COMMAND
+    patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_xcompile_android_patch.diff
   CONFIGURE_COMMAND ${AIRMAP_BOOST_BOOTSTRAP_COMMAND}
   BUILD_COMMAND
     ${AIRMAP_BOOST_B2_COMMAND}

--- a/vendor/boost/patches/fix_xcompile_android_patch.diff
+++ b/vendor/boost/patches/fix_xcompile_android_patch.diff
@@ -1,0 +1,31 @@
+diff --git tools/build/src/tools/common.jam tools/build/src/tools/common.jam
+index 5b9b3508..b399916c 100644
+--- tools/build/src/tools/common.jam
++++ tools/build/src/tools/common.jam
+@@ -974,16 +974,16 @@ local rule toolset-tag ( name : type ? : property-set )
+     }
+
+     # From GCC 5, versioning changes and minor becomes patch
+-    if $(tag) = gcc && [ numbers.less 4 $(version[1]) ]
+-    {
+-        version = $(version[1]) ;
+-    }
+-
+-    # Ditto, from Clang 4
+-    if ( $(tag) = clang || $(tag) = clangw ) && [ numbers.less 3 $(version[1]) ]
+-    {
+-        version = $(version[1]) ;
+-    }
++    # if $(tag) = gcc && [ numbers.less 4 $(version[1]) ]
++    # {
++    #     version = $(version[1]) ;
++    # }
++
++    # # Ditto, from Clang 4
++    # if ( $(tag) = clang || $(tag) = clangw ) && [ numbers.less 3 $(version[1]) ]
++    # {
++    #     version = $(version[1]) ;
++    # }
+
+     # On intel, version is not added, because it does not matter and it is the
+     # version of vc used as backend that matters. Ideally, we should encode the


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
[A previous PR](https://github.com/airmap/platform-sdk/pull/149) has broken cross-compile for Android. This fixes it and puts it under the [CI control](https://github.com/airmap/platform-sdk/pull/151/files#diff-5cacf23785f4a3ae06a1831e95b465ccR61). 

It appears to reliably build `platform-sdk` for Android:
```
file ../installed/lib/libairmap-cpp.so
../installed/lib/libairmap-cpp.so: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, BuildID[sha1]=dac6c129f9297246679d8005cc8b6a5df59c6ac4, with debug_info, not stripped
```

## Notes
Related to a known x-compile problem for 1.70: https://github.com/boostorg/build/issues/385
