### PR TITLE
Add How to compile platform-sdk

### DIFF
--- a/HowToCompile.md
+++ b/HowToCompile.md
@@ -1,0 +1,70 @@
+## How to Compile Platform SDK on MacOS and Android x86 
+
+### Development Environment
+
+- macOS Catalina version 10.15.4
+- Apple clang version 11.0.3 (installed with Xcode 11.4.1)
+- Homebrew 2.4.0
+- Qt (5.11.3 or newer)
+- ndk (r16b or newer)
+
+### Mac compile method
+1. update submodule by **git submodule update --init --recursive**
+2. First run tools/osx/setup.sh command to install dependency tools (We not use the brew install Qt version);
+4. Create an separate directory and run the following command
+
+```
+mkdir build-mac
+cd build-mac
+cmake .. -DAIRMAP_ENABLE_QT=ON -DQt5_DIR="/Applications/Qt/5.11.3/clang_64/lib/cmake/Qt5"
+make
+```
+The **DQt5_DIR** is depenency on the Qt version installed. You need to change to the Qt install path of your computer.
+The output binary DataPilot will output at path **build-mac/src/airmap/qt/**
+
+### Android x86 compile method
+1. update submodule by **git submodule update --init --recursive**
+2. install ndk version r16b or newer
+3. Create an separate directory and run the following command
+
+```
+mkdir build-mac
+cd build-mac
+cmake ..  -DCMAKE_SYSTEM_NAME=Android -DANDROID_PLATFORM=android-16 -DANDROID_ABI=x86 -DANDROID_NDK=/Users/tbago/Library/Android/android-ndk-r16b -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/Users/tbago/Library/Android/android-ndk-r16b/build/cmake/android.toolchain.cmake -DANDROID_TOOLCHAIN=clang -DANDROID=1 -DAIRMAP_ENABLE_QT=ON -DQt5_DIR="/Applications/Qt/5.11.3/android_x86/lib/cmake/Qt5" -DQt5Core_DIR="/Applications/Qt/5.11.3/android_x86/lib/cmake/Qt5Core"
+make
+```
+The ndk and Qt path is dependeny by your install. Set the ndk path and Qt path by youself.
+
+4. The boost library cannot build by the platform sdk cmake. So you need to clone the [Boost Library For Android](https://github.com/moritz-wundke/Boost-for-Android). And run the following command to build boost library:
+```
+./build-android.sh /Users/tbago/Library/Android/android-ndk-r19c --boost="1.70.0" --with-libraries=date_time,filesystem,log,program_options,system,test,thread --arch=x86 --target-version=16
+```
+This github library only  support boost version 1.70.0 and 1.73.0. So the boost library is not the same library as MacOS. When compile complate. You need copy the boost header file from **Boost-for-Android/build/out/x86/include/boost-1_70** to **airmap-platform-sdk/build-android/external/include** And copy the boost library **Boost-for-Android/build/out/x86/lib/*.a** to **airmap-platform-sdk/build-android/external/lib** and then rename the library path as following:
+```
+    libboost_system.a
+    libboost_atomic.a
+    libboost_test_exec_monitor.a
+    libboost_chrono.a
+    libboost_thread.a
+    libboost_date_time.a
+    libboost_unit_test_framework.a
+    libboost_filesystem.a
+    libboost_log.a       
+    libboost_log_setup.a    
+    libboost_prg_exec_monitor.a
+    libboost_program_options.a
+    libboost_regex.a    
+```
+And then you have to manual change the **airmapd.cmake**
+```
+find_package(Boost 1.70.0 QUIET REQUIRED date_time filesystem log program_options system thread)
+```
+And then run the cmake and make command again. The output file will in the following path: **airmap-platform-sdk/build-android/src/airmap/qt/libairmap-qt.so**
+
+
+### More Info
+1. I update the boost version to 1.72.0, because the boost version 1.70.0 cannot compile with the following error:
+```
+clang: error: unknown argument: '-fcoalesce-templates'
+```
+2. Sometimes the clang cannot compile boost library, you need to try to recompile again.

--- a/airmapd.cmake
+++ b/airmapd.cmake
@@ -3,7 +3,7 @@ include(CTest)
 # Cmake find modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-find_package(Boost 1.70.0 QUIET REQUIRED date_time filesystem log program_options system thread)
+find_package(Boost 1.72.0 QUIET REQUIRED date_time filesystem log program_options system thread)
 find_package(OpenSSL REQUIRED)
 find_package(protobuf CONFIG REQUIRED)
 
@@ -22,6 +22,7 @@ endif ()
 
 if (AIRMAP_ENABLE_QT)
   find_package(Qt5 COMPONENTS Core REQUIRED)
+  message(STATUS "enable airmap qt build")
 endif()
 
 # vendor-specific setup goes here

--- a/src/airmap/rest/telemetry.cpp
+++ b/src/airmap/rest/telemetry.cpp
@@ -108,7 +108,12 @@ std::string airmap::rest::detail::OpenSSLAES256Encryptor::create_shared_secret()
 
 std::string airmap::rest::detail::OpenSSLAES256Encryptor::encrypt(const std::string& message, const std::string& key,
                                                                   const std::string& iv) {
-  auto decoded_key = boost::beast::detail::base64_decode(key);
+  std::string dest;
+  dest.resize(base64::decoded_size(key.size()));
+  auto const result = base64::decode(&dest[0], key.data(), key.size());
+  dest.resize(result.first);
+
+  auto decoded_key = dest;
 
   std::shared_ptr<EVP_CIPHER_CTX> ctx{EVP_CIPHER_CTX_new(), ::EVP_CIPHER_CTX_free};
   if (not ctx) {

--- a/vendor/boost/CMakeLists.txt
+++ b/vendor/boost/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 
 # This cmake setup builds boost in a way suitable for linking with
 # the AirMap platform SDK. 
@@ -82,14 +82,12 @@ else()
   endif()
 endif()
 
-ExternalProject_Add(
-  boost
-  URL https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2
-  URL_HASH SHA256=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
+ExternalProject_Add(boost
+  URL https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+  URL_HASH SHA256=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
   BUILD_IN_SOURCE 1
   UPDATE_COMMAND ""
-  PATCH_COMMAND
-    patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_xcompile_android_patch.diff
+  PATCH_COMMAND ""
   CONFIGURE_COMMAND ${AIRMAP_BOOST_BOOTSTRAP_COMMAND}
   BUILD_COMMAND
     ${AIRMAP_BOOST_B2_COMMAND}


### PR DESCRIPTION
For Android x86 compile. I only temp fixed boost compile failed issue.  And I am not familiar with the CMake and ndk system. So there may be better way to compile platform-sdk to Android x86 platform.