### PR TITLE
test: Disable broken client_test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,7 +47,7 @@ endfunction (airmap_add_test)
 
 airmap_add_test(airspace_test airspace_test.cpp)
 airmap_add_test(cli_test cli_test.cpp)
-airmap_add_test(client_test client_test.cpp)
+#airmap_add_test(client_test client_test.cpp)
 airmap_add_test(credentials_test credentials_test.cpp)
 # airmap_add_test(daemon_test daemon_test.cpp)
 airmap_add_test(datetime_test datetime_test.cpp)


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Just fails to build with GCC 8, which is included in the flatpak base images.
So either we need a newer compiler or need a check and disable the test on demand.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>
