### PR TITLE
airmapd: Cleanup decrepit section

### DIFF
--- a/airmapd.cmake
+++ b/airmapd.cmake
@@ -8,12 +8,15 @@ find_package(OpenSSL REQUIRED)
 find_package(protobuf CONFIG REQUIRED)
 
 find_library(
-  WE_NEED_BORINGSSLS_LIB_DECREPIT libdecrepit.a
+  WE_NEED_BORINGSSLS_LIB_DECREPIT
+  NAMES libdecrepit.a decrepit
   PATHS ${AIRMAP_EXTERNAL_DEPENDENCIES_OUTPUT_PATH}
 )
 
-if (NOT WE_NEED_BORINGSSLS_LIB_DECREPIT)
-  message(FATAL_ERROR "Failed to find libdecrepit.a")
+if (WE_NEED_BORINGSSLS_LIB_DECREPIT)
+  message(STATUS "Found decrepit: ${WE_NEED_BORINGSSLS_LIB_DECREPIT}")
+else ()
+  message(FATAL_ERROR "Failed to find decrepit")
 endif ()
 
 if (AIRMAP_ENABLE_GRPC)


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Allow lookup of shared library, but keep preferring static one.
Also adding a meaningful debug/error message.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>