### PR TITLE
[PATH-147] ubuntu 18.04 -> ubuntu 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       - run: cd build && make -j4
       - run: cd build && ctest -V
       - run: cd build && make install
-  build-and-test-ubuntu-18.04-gcc:
+  build-and-test-ubuntu-20.04-gcc:
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu:20.04
     steps:
       - checkout
       - run: tools/ubuntu/setup.dev.sh
@@ -24,9 +24,9 @@ jobs:
       - run: cd build && make -j4
       - run: cd build && ctest -V
       - run: cd build && make install
-  build-and-test-ubuntu-18.04-clang:
+  build-and-test-ubuntu-20.04-clang:
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu:20.04
     steps:
       - checkout
       - run: tools/ubuntu/setup.dev.sh
@@ -39,7 +39,7 @@ jobs:
       - run: cd build && make install
   build-android-ndk-r17c-api-level-21:
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu:20.04
     steps:
       - checkout
       - run: tools/ubuntu/setup.dev.sh
@@ -58,6 +58,6 @@ workflows:
   build_and_test:
     jobs:
       - build-and-test-macos-xcode-10.0.0
-      - build-and-test-ubuntu-18.04-gcc
-      - build-and-test-ubuntu-18.04-clang
+      - build-and-test-ubuntu-20.04-gcc
+      - build-and-test-ubuntu-20.04-clang
       - build-android-ndk-r17c-api-level-21

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Make sure that you start with a clean environment (fresh clone of the AirMap Pla
 Run the following commands from the top-level `platform-sdk` folder:
 
 ```
-docker run -v $(pwd):/platform-sdk -w /platform-sdk -it ubuntu:18.04 bash
+docker run -v $(pwd):/platform-sdk -w /platform-sdk -it ubuntu:20.04 bash
 tools/ubuntu/setup.dev.sh
 mkdir build
 cd build

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -15,7 +15,7 @@ jobs:
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     timeoutInMinutes: 0
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
       - checkout: self
         clean: true
@@ -89,7 +89,7 @@ jobs:
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
     timeoutInMinutes: 0
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-20.04"
     steps:
     - checkout: self
       clean: true

--- a/docker/android
+++ b/docker/android
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docker/ubuntu
+++ b/docker/ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/tools/ubuntu/cleanup.dev.sh
+++ b/tools/ubuntu/cleanup.dev.sh
@@ -17,7 +17,7 @@ apt remove -y \
 apt autoremove -y
 
 # Now reinstall all our runtime dependencies
-apt install -y libc-ares2 libssl1.0.0
+apt install -y libc-ares2 libssl1.1
 
 # And remove all cached debian packages
 apt clean

--- a/tools/ubuntu/setup.dev.sh
+++ b/tools/ubuntu/setup.dev.sh
@@ -4,7 +4,7 @@ set -ex
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 apt update
-
+export DEBIAN_FRONTEND=noninteractive
 apt install -y \
   build-essential \
   curl \


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Use Ubuntu 20.04 instead of 18.04 since support for 18.04 has ended.

## Todos
- [x] Tests
- [x] Documentation


## Notes
This is a prerequisite for using C++ 17 and std::filesystem.

## Impacted Areas in AirMap Platform SDK
List general components of the SDK that this PR will affect:

* Only Docker images used and CI
