### PR TITLE
[PATH-145] update cpp version to 17

### DIFF
--- a/examples/monitor/CMakeLists.txt
+++ b/examples/monitor/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(
 
     client.cpp)
 
-set_property(TARGET monitor.client PROPERTY CXX_STANDARD 14)
+set_property(TARGET monitor.client PROPERTY CXX_STANDARD 17)
 
 target_link_libraries(
   monitor.client

--- a/examples/qt/CMakeLists.txt
+++ b/examples/qt/CMakeLists.txt
@@ -1,6 +1,6 @@
 qt5_wrap_cpp(mocs client.h)
 add_executable(qt.client client.cpp ${mocs})
-set_property(TARGET qt.client PROPERTY CXX_STANDARD 14)
+set_property(TARGET qt.client PROPERTY CXX_STANDARD 17)
 target_link_libraries(
     qt.client
 

--- a/interfaces/grpc/CMakeLists.txt
+++ b/interfaces/grpc/CMakeLists.txt
@@ -56,7 +56,7 @@ add_library(
 
 set_property(
     TARGET airmap-interfaces-grpc 
-    PROPERTY CXX_STANDARD 14
+    PROPERTY CXX_STANDARD 17
 )
 
 target_compile_options(

--- a/src/airmap/CMakeLists.txt
+++ b/src/airmap/CMakeLists.txt
@@ -211,7 +211,7 @@ add_library(
 
 set_property(
   TARGET airmap-client
-  PROPERTY CXX_STANDARD 14
+  PROPERTY CXX_STANDARD 17
 )
 
 set_property(

--- a/src/airmap/cmds/airmap/CMakeLists.txt
+++ b/src/airmap/cmds/airmap/CMakeLists.txt
@@ -73,7 +73,7 @@ add_executable(
 
 set_property(
   TARGET airmap
-  PROPERTY CXX_STANDARD 14
+  PROPERTY CXX_STANDARD 17
 )
 
 if (AIRMAP_ENABLE_GRPC)

--- a/src/airmap/codec/grpc/CMakeLists.txt
+++ b/src/airmap/codec/grpc/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(
 
 set_property(
   TARGET airmap-codec-grpc
-  PROPERTY CXX_STANDARD 14
+  PROPERTY CXX_STANDARD 17
 )
 
 set_property(

--- a/src/airmap/cpp/CMakeLists.txt
+++ b/src/airmap/cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(
 set_target_properties(
   airmap-cpp PROPERTIES
 
-  CXX_STANDARD      14
+  CXX_STANDARD      17
   SOVERSION         "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
   VERSION           "${PROJECT_VERSION_MAJOR}"
 )

--- a/src/airmap/grpc/CMakeLists.txt
+++ b/src/airmap/grpc/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
 
 set_property(
   TARGET airmap-grpc
-  PROPERTY CXX_STANDARD 14
+  PROPERTY CXX_STANDARD 17
 )
 
 set_property(

--- a/src/airmap/mavlink/CMakeLists.txt
+++ b/src/airmap/mavlink/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(
 
 set_property(
   TARGET airmap-mavlink
-  PROPERTY CXX_STANDARD 14)
+  PROPERTY CXX_STANDARD 17)
   
 set_property(
   TARGET airmap-mavlink

--- a/src/airmap/monitor/CMakeLists.txt
+++ b/src/airmap/monitor/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(
 
 set_property(
   TARGET airmap-monitor
-  PROPERTY CXX_STANDARD 14
+  PROPERTY CXX_STANDARD 17
 )
 
 set_property(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ function(airmap_add_test name source)
 
     ${source})
 
-  set_property(TARGET ${name} PROPERTY CXX_STANDARD 14)
+  set_property(TARGET ${name} PROPERTY CXX_STANDARD 17)
   target_link_libraries(
     ${name}
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
Use C++ 17 instead of 14.

## Related PRs
List related pull requests against other branches:
https://github.com/airmap/platform-sdk/pull/187

branch | PR
------ | ------
tim/move_to_ubuntu_20_04 | [link](https://github.com/airmap/platform-sdk/pull/187)

## Todos
- [x] Tests
- [ ] Documentation


## Notes
Allows us to use std::filesystem

## Impacted Areas in AirMap Platform SDK
List general components of the SDK that this PR will affect:

* Components we own
