### PR TITLE
remove gh auth login command

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -95,13 +95,12 @@ jobs:
           curl -fsSL https://github.com/cli/cli/releases/download/v2.0.0/gh_2.0.0_linux_amd64.tar.gz | tar -xzf - --no-anchored gh --strip-components 2
           chmod a+x gh
           ./gh config set prompt disabled
-            # auth token supplied via ENV configured in pipeline variables setup
-          ./gh auth login
             # assume release version is most recent existing tag in repo
           VERSION="$(git describe --abbrev=0 --tags)"
           ./gh release create --repo=airmap/platform-sdk "$VERSION" "$(Build.ArtifactStagingDirectory)"/airmap-platform-sdk-*.deb
         displayName: "Create GitHub release"
         env:
+          # auth token supplied via ENV configured in pipeline variables setup
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
   - job: "pr"


### PR DESCRIPTION
## Status
**READY**

## Description
The `gh auth login` command isn't necessary if the GITHUB_TOKEN env variable is set.
