### PR TITLE
misc changes to build outside of docker

### DIFF
--- a/airmapd.cmake
+++ b/airmapd.cmake
@@ -5,7 +5,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(Boost 1.70.0 QUIET REQUIRED date_time log program_options system thread)
 find_package(OpenSSL REQUIRED)
-find_package(protobuf CONFIG REQUIRED)
+find_package(Protobuf REQUIRED)
 
 find_library(
   WE_NEED_BORINGSSLS_LIB_DECREPIT
@@ -47,7 +47,10 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}/src
 
   ${Boost_INCLUDE_DIRS}
-  ${OPENSSL_INCLUDE_DIRS})
+  ${OPENSSL_INCLUDE_DIRS}
+  
+  SYSTEM
+  ${Protobuf_INCLUDE_DIRS})
 
 add_subdirectory(doc)
 add_subdirectory(interfaces)

--- a/docker/android
+++ b/docker/android
@@ -13,6 +13,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE
 	-DANDROID_PLATFORM=android-25 \
 	-DANDROID_STL=c++_shared \
 	-DANDROID_CPP_FEATURES="rtti exceptions" \
+	-DANDROID_LINKER_FLAGS="-llog" \
 	-DCMAKE_TOOLCHAIN_FILE=/tmp/android-ndk-r25b/build/cmake/android.toolchain.cmake \
 	..
 RUN make

--- a/src/airmap/rest/telemetry.cpp
+++ b/src/airmap/rest/telemetry.cpp
@@ -108,7 +108,8 @@ std::string airmap::rest::detail::OpenSSLAES256Encryptor::create_shared_secret()
 
 std::string airmap::rest::detail::OpenSSLAES256Encryptor::encrypt(const std::string& message, const std::string& key,
                                                                   const std::string& iv) {
-  auto decoded_key = boost::beast::detail::base64_decode(key);
+  std::string decoded_key;
+  boost::beast::detail::base64::decode((void*)&decoded_key, (const char*)&key, key.size());
 
   std::shared_ptr<EVP_CIPHER_CTX> ctx{EVP_CIPHER_CTX_new(), ::EVP_CIPHER_CTX_free};
   if (not ctx) {

--- a/src/airmap/rest/telemetry.cpp
+++ b/src/airmap/rest/telemetry.cpp
@@ -109,7 +109,8 @@ std::string airmap::rest::detail::OpenSSLAES256Encryptor::create_shared_secret()
 std::string airmap::rest::detail::OpenSSLAES256Encryptor::encrypt(const std::string& message, const std::string& key,
                                                                   const std::string& iv) {
   std::string decoded_key;
-  boost::beast::detail::base64::decode((void*)&decoded_key, (const char*)&key, key.size());
+  decoded_key.resize(boost::beast::detail::base64::decoded_size(key.size()));
+  decoded_key.resize(boost::beast::detail::base64::decode((void*)&decoded_key, (const char*)&key, key.size()).first);
 
   std::shared_ptr<EVP_CIPHER_CTX> ctx{EVP_CIPHER_CTX_new(), ::EVP_CIPHER_CTX_free};
   if (not ctx) {

--- a/src/airmap/rest/telemetry.cpp
+++ b/src/airmap/rest/telemetry.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <sstream>
+#include <cassert>
 
 namespace base64 = boost::beast::detail::base64;
 namespace fmt    = airmap::util::fmt;
@@ -108,9 +109,10 @@ std::string airmap::rest::detail::OpenSSLAES256Encryptor::create_shared_secret()
 
 std::string airmap::rest::detail::OpenSSLAES256Encryptor::encrypt(const std::string& message, const std::string& key,
                                                                   const std::string& iv) {
-  std::string decoded_key;
-  decoded_key.resize(boost::beast::detail::base64::decoded_size(key.size()));
-  decoded_key.resize(boost::beast::detail::base64::decode((void*)&decoded_key, (const char*)&key, key.size()).first);
+  const size_t decoded_size = boost::beast::detail::base64::decoded_size(key.size());
+  std::unique_ptr<unsigned char[]> decoded_key(new unsigned char[decoded_size]);
+  auto res = boost::beast::detail::base64::decode(decoded_key.get(), key.data(), key.size());
+  assert(res.first <= decoded_size && res.second == key.size());
 
   std::shared_ptr<EVP_CIPHER_CTX> ctx{EVP_CIPHER_CTX_new(), ::EVP_CIPHER_CTX_free};
   if (not ctx) {
@@ -118,7 +120,7 @@ std::string airmap::rest::detail::OpenSSLAES256Encryptor::encrypt(const std::str
   }
 
   if (EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr,
-                         reinterpret_cast<const unsigned char*>(decoded_key.data()),
+                         const_cast<const unsigned char*>(decoded_key.get()),
                          reinterpret_cast<const unsigned char*>(iv.data())) != 1) {
     throw std::runtime_error{"failed to initialize encryption context"};
   }

--- a/vendor/boringssl/CMakeLists.txt
+++ b/vendor/boringssl/CMakeLists.txt
@@ -17,7 +17,7 @@ endif ()
 ExternalProject_add(
     boringssl
     GIT_REPOSITORY https://github.com/google/boringssl.git
-    GIT_TAG ddecaabdc8c950d1417ed69785ac17c3400bae4c
+    GIT_TAG 597ffef971dd980b7de5e97a0c9b7ca26eec94bc
     PREFIX boringssl
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
These are the changes I had to make so I could build platform-sdk outside of the ubuntu 20.04 docker image

The boringssl change just uses a newer tag that has fixed this issue: https://github.com/nmeum/android-tools/issues/16
This is the commit that fixes it: https://boringssl.googlesource.com/boringssl/+/92c6fbfc4c44dc8462d260d836020d2b793e7804
The hash is different because we are using the github mirror.

The change to telemetry.cpp is to fix the same issue described here: https://github.com/prusa3d/PrusaSlicer/issues/3175
Seems like the boost function we were using was not intended for general use and was removed.
Here's the commit that the PrusaSlicer people made to fix it, which I followed to make my change: https://github.com/prusa3d/PrusaSlicer/commit/621b8426d3855a9b7c9c998a3d32a1adcb9fd284

The protobuf include issues just seem to be a mistake. We didn't have the protobuf_INCLUDE_DIRS in the include directories, and were using the `CONFIG` option. That's not mentioned in the protobuf cmake documentation, and removing it fixed the include issues for me.


## Testing
I made sure platform-sdk can still build in docker, and ran the unit tests and integration tests.
